### PR TITLE
Fixed 🐞: Persist Dark Mode/Light Mode Preference Across Page Refreshes

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -1,8 +1,24 @@
+document.addEventListener("DOMContentLoaded", function() {
+    const content = document.getElementsByTagName('body')[0];
+    const toggle = document.getElementById('toggle');
 
-const content = document.getElementsByTagName('body')[0];
-const darkMode = document.getElementById('toggle')
+    // Check for saved dark mode preference in localStorage
+    const darkModeEnabled = localStorage.getItem('darkMode') === 'true';
 
-toggle.addEventListener('click', function(){
-    toggle.classList.toggle('active');
-    content.classList.toggle("night")
-})
+    if (darkModeEnabled) {
+        toggle.classList.add('active');
+        content.classList.add('night');
+    } else {
+        toggle.classList.remove('active');
+        content.classList.remove('night');
+    }
+
+    // Toggle dark mode on button click
+    toggle.addEventListener('click', function() {
+        const darkModeEnabled = content.classList.toggle('night');
+        toggle.classList.toggle('active');
+
+        // Save dark mode state in localStorage
+        localStorage.setItem('darkMode', darkModeEnabled);
+    });
+});


### PR DESCRIPTION
Hey @SyedImtiyaz-1 
This PR adds functionality to persist the user's dark mode or light mode preference across page refreshes using localStorage. The changes ensure that the chosen theme state (either dark or light) remains consistent even after the user reloads the page.

Issue Closes #500

### Changes I made
- Added an event listener for the `DOMContentLoaded` event to ensure the script runs after the HTML is fully loaded.
- Implemented a check for a saved `dark mode` preference in `localStorage`upon page load.
- Applied the appropriate classes (night and active) based on the saved preference.
- Saved the current theme state to `localStorage` to ensure persistence across page refreshes.


### Before Changes 
Previously, the dark mode/light mode preference would reset after a page refresh, leading to a suboptimal user experience. By persisting the theme state in localStorage, users will have a consistent experience aligned with their chosen preference.

### After Changes
The changes ensure that the chosen theme state (either dark or light) remains consistent even after the user reloads the page.

### How to Test:
- Load the page and click the theme toggle button to switch to dark mode.
- Refresh the page and verify that dark mode persists.
- Click the toggle button again to switch back to light mode.
- Refresh the page and verify that light mode persists.

Please take a look and review it, Thank You!